### PR TITLE
Fix renaming command

### DIFF
--- a/UPD_study/data/data_preprocessing/prepare_BraTS.sh
+++ b/UPD_study/data/data_preprocessing/prepare_BraTS.sh
@@ -10,7 +10,7 @@ rm -r UPD_study/data/datasets/MRI/BraTS2020_ValidationData
 mv UPD_study/data/datasets/MRI/BraTS2020_TrainingData/* UPD_study/data/datasets/MRI/BraTS
 rm -r UPD_study/data/datasets/MRI/BraTS2020_TrainingData
 # fix a mistake in the naming
-mv UPD_study/data/datasets/MRI/BraTS/MICCAI_BraTS2020_TrainingData/BraTS20_Training_355/W39_1998.09.19_Segm.nii UPD_study/data/datasets/MRI/BraTS/MICCAI_BraTS2020_TrainingData/BraTS20_Training_355/W39_1998.09.19_Segm.nii UPD_study/data/datasets/MRI/BraTS/MICCAI_BraTS2020_TrainingData/BraTS20_Training_355/W39_1998.09.19_Segm.nii UPD_study/data/datasets/MRI/BraTS/MICCAI_BraTS2020_TrainingData/BraTS20_Training_355/BraTS20_Training_355_seg.nii 
+mv UPD_study/data/datasets/MRI/BraTS/MICCAI_BraTS2020_TrainingData/BraTS20_Training_355/W39_1998.09.19_Segm.nii UPD_study/data/datasets/MRI/BraTS/MICCAI_BraTS2020_TrainingData/BraTS20_Training_355/BraTS20_Training_355_seg.nii 
 
 # Register and skullstrip
 python UPD_study/data/data_preprocessing/prepare_data.py --dataset BraTS


### PR DESCRIPTION
When I tried running `prepare_BraTS.sh` I had an error saying that the segmentation for sample 355 was missing, and the folder still contained the badly namied `W39...` file. I think the extra args are stopping the mv from happening (maybe it's only considering the first two args so misses the real final one?). Removing the middle repeated args seems to fix this.

 Not exactly related, but while I was getting BraTS loaded I also noticed:
 - There are 369 files, not 371 (at least in the kaggle download, idk if that ever changes)
 - Currently only the last 15 BraTS volumes are registered (filtered [here](https://github.com/iolag/UPD_study/blob/5e3dd6a695d8e83e47bacb9484c35b48c291c006/UPD_study/data/data_preprocessing/prepare_data.py#L54)). I haven't run a full model evaluation yet, but it seems like the evaluation code only picks up registered files, so then only 15 BraTS samples are used to test. Was this just set to debug fast or are your reported numbers only on these slices?
 
 Also, just to be clear, I do really value the work you've put into this benchmark. It's something the OOD community haven't had yet, so everyone has been working on almost random train/test set combinations, so having this set a standard which everyone can compare against is really helpful :smile: .
 Unfortunately I can't read code fast enough to put all my suggestions/questions in one post, so hopefully this doesn't get annoying, if it is I can batch try to them. 