### PR TITLE
Fix ATLAS preprocessing

### DIFF
--- a/UPD_study/data/data_preprocessing/prepare_data.py
+++ b/UPD_study/data/data_preprocessing/prepare_data.py
@@ -229,8 +229,8 @@ class ATLASHandler():
                                f' from https://fcon_1000.projects.nitrc.org/indi/retro/atlas_download.html'
                                f' and extract to {args.dataset_path}')
         self.rename_lesions(args)
-        self.registerATLAS(args)
         self.skull_strip_ATLAS(args)
+        self.registerATLAS(args)
 
     @staticmethod
     def rename_lesions(args):

--- a/UPD_study/data/data_preprocessing/robex.py
+++ b/UPD_study/data/data_preprocessing/robex.py
@@ -34,11 +34,18 @@ def strip_skull_ROBEX(paths, out_dir: Optional[str] = None,
     batches = [list(p) for p in np.array_split(paths, num_processes) if len(p) > 0]
     print(f"Skull stripping is using {len(batches)} cpu cores")
 
+    processes = []
     # Start multiprocessing
     for i, batch in enumerate(batches):
         p = multiprocessing.Process(
             target=_strip_skull_ROBEX, args=(batch, i, out_dir,))
         p.start()
+        processes.append(p)
+
+    # Wait for all processes to finish
+    print("Waiting for ROBEX to finish")
+    for p in processes:
+        p.join()
 
 
 def _strip_skull_ROBEX(paths: List[str], i_process: int,

--- a/UPD_study/data/dataloaders/PII_RF.py
+++ b/UPD_study/data/dataloaders/PII_RF.py
@@ -33,11 +33,11 @@ def get_files(config: Namespace, train: bool = True) -> Union[List, Tuple[List, 
     """
 
     norm_paths = sorted(
-        glob(os.path.join(config.datasets_dir, 'DDR-dataset', 'healthy', '*.jpg')))
+        glob(os.path.join(config.datasets_dir, 'RF', 'DDR-dataset', 'healthy', '*.jpg')))
     anom_paths = sorted(glob(os.path.join(config.datasets_dir,
-                        'DDR', 'unhealthy', 'images', '*.png')))
+                                          'RF', 'DDR-dataset', 'unhealthy', 'images', '*.png')))
 
-    segmentations = sorted(glob(os.path.join(config.datasets_dir, 'DDR-dataset',
+    segmentations = sorted(glob(os.path.join(config.datasets_dir, 'RF', 'DDR-dataset',
                                              'unhealthy', 'segmentations', '*.png')))
     if train:
         return norm_paths[757:]


### PR DESCRIPTION
Got onto ATLAS preprocessing, I will check CamCAN next but still waiting for authorisation to get the data.

Changes:
- Change ROBEX to wait until all processes are finished, otherwise the function returns whilst the skull-stripping is ongoing and the registering crashes as the files aren't ready yet.
- Swap registration to go after skull stripping

Related to ATLAS, currently the preprocessing loads 655 samples, which matches the training set size on the  [dataset site](https://fcon_1000.projects.nitrc.org/indi/retro/atlas.html), but the paper says the dataset has 220 samples. Did you do an extra filtering step that isn't in the repo?

No need to reply urgently, if you're already away on holiday then leave this until you get back :) 