### PR TITLE
expVAE evaluation fails if an input has batch size 1

### DIFF
--- a/UPD_study/models/expVAE/gradcam.py
+++ b/UPD_study/models/expVAE/gradcam.py
@@ -65,7 +65,7 @@ class GradCAM(PropBase):
         return grads / l2_norm.item()
 
     def compute_gradient_weights(self):
-        self.grads = self.normalize(self.grads.squeeze())
+        self.grads = self.normalize(self.grads)
         self.map_size = self.grads.size()[2:]
         self.weights = nn.AvgPool2d(self.map_size)(self.grads)
 


### PR DESCRIPTION
Removing squeeze that causes inconsistent shapes, which ultimately makes evaluation fail when encountering an input tensor with  batch 1